### PR TITLE
Change CSS to format Parmenides hypotheses

### DIFF
--- a/se-lint-ignore.xml
+++ b/se-lint-ignore.xml
@@ -18,6 +18,12 @@
 			<reason>Roman numerals are numbers for a list, so the period after the numeral is correct.</reason>
 		</ignore>
 	</file>
+	<file path="parmenides.xhtml">
+		<ignore>
+			<code>t-042</code>
+			<reason>The paragraph leads directly into the next section of hypotheses, so no ending punctuation needed.</reason>
+		</ignore>
+	</file>
 	<file path="theaetetus.xhtml">
 		<ignore>
 			<code>t-029</code>

--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -190,13 +190,49 @@ i [epub|type~="z3998:persona"]{
 }
 /* End analogy CSS */
 
-/* Custom CSS for "theses" listed in Gorgias and Parmenides introductions */
+/* Custom CSS for "theses" listed in Gorgias introduction */
 .thesis{
 	margin: 1em;
 	text-align: center;
 	text-indent: 0;
 }
-/* End thesis CSS */
+/* End theses CSS */
+
+/* Custom CSS for "hypotheses" with specialized indentation listed in the Parmenides introduction */
+.hypothesis{
+	margin-bottom: 1em;
+	margin-top: 1em;
+}
+
+.hypothesis > span{
+	display: block;
+	text-indent: 0;
+}
+
+.hypothesis > span + br{
+	display: none;
+}
+
+p span.thesis-indent1{
+	padding-left: 5em;
+	text-indent: -2em;
+}
+
+p span.thesis-indent2{
+	padding-left: 6em;
+	text-indent: -2em;
+}
+
+p span.thesis-indent4{
+	padding-left: 8em;
+	text-indent: -2em;
+}
+
+p span.thesis-indent6{
+	padding-left: 10em;
+	text-indent: -2em;
+}
+/* End hypotheses CSS */
 
 /* Custom CSS for fractions in Timaeus introduction */
 .fractions{

--- a/src/epub/text/parmenides.xhtml
+++ b/src/epub/text/parmenides.xhtml
@@ -47,25 +47,45 @@
 				<p>Other critics have regarded the final conclusion of the “Parmenides” either as sceptical or as Heracleitean. In the first case, they assume that Plato means to show the impossibility of any truth. But this is not the spirit of Plato, and could not with propriety be put into the mouth of Parmenides, who, in this very dialogue, is urging Socrates, not to doubt everything, but to discipline his mind with a view to the more precise attainment of truth. The same remark applies to the second of the two theories. Plato everywhere ridicules (perhaps unfairly) his Heracleitean contemporaries: and if he had intended to support an Heracleitean thesis, would hardly have chosen Parmenides, the condemner of the “undiscerning tribe who say that things both are and are not,” to be the speaker. Nor, thirdly, can we easily persuade ourselves with Zeller that by the “one” he means the Idea; and that he is seeking to prove indirectly the unity of the Idea in the multiplicity of phenomena.</p>
 				<p>We may now endeavour to thread the mazes of the labyrinth which Parmenides knew so well, and trembled at the thought of them.</p>
 				<p>The argument has two divisions: There is the hypothesis that</p>
-				<p class="thesis"><span epub:type="z3998:roman">I</span>. One is.<br/>
-				<span epub:type="z3998:roman">II</span>. One is not.<br/>
-				If one is, it is nothing.<br/>
-				If one is not, it is everything.</p>
+				<p class="hypothesis">
+					<span class="thesis-indent6"><span epub:type="z3998:roman">I</span>. One is.</span>
+					<br/>
+					<span class="thesis-indent6"><span epub:type="z3998:roman">II</span>. One is not.</span>
+					<br/>
+					<span class="thesis-indent4">If one is, it is nothing.</span>
+					<br/>
+					<span class="thesis-indent4">If one is not, it is everything.</span>
+				</p>
 				<p>But is and is not may be taken in two senses:</p>
-				<p class="thesis">Either one is one,<br/>
-				Or, one has being,</p>
+				<p class="hypothesis">
+					<span class="thesis-indent6">Either one is one,</span>
+					<br/>
+					<span class="thesis-indent6">Or, one has being,</span>
+				</p>
 				<p class="continued">from which opposite consequences are deduced,</p>
-				<p class="thesis"><span epub:type="z3998:roman">I</span>.a. If one is one, it is nothing (<a href="#parmenides-p-236">137 C</a>⁠–⁠<a href="#parmenides-p-445">142 B</a>).<br/>
-				<span epub:type="z3998:roman">I</span>.b. If one has being, it is all things (<a href="#parmenides-p-445">142 B</a>⁠–⁠<a href="#parmenides-p-963">157 B</a>).</p>
+				<p class="hypothesis">
+					<span class="thesis-indent2"><span epub:type="z3998:roman">I</span>.a. If one is one, it is nothing (<a href="#parmenides-p-236">137 C</a>⁠–⁠<a href="#parmenides-p-445">142 B</a>).</span>
+					<br/>
+					<span class="thesis-indent2"><span epub:type="z3998:roman">I</span>.b. If one has being, it is all things (<a href="#parmenides-p-445">142 B</a>⁠–⁠<a href="#parmenides-p-963">157 B</a>).</span>
+				</p>
 				<p>To which are appended two subordinate consequences:</p>
-				<p class="thesis"><span epub:type="z3998:roman">I</span>.aa. If one has being, all other things are (<a href="#parmenides-p-963">157 B</a>⁠–⁠<a href="#parmenides-p-1029">159 B</a>).<br/>
-				<span epub:type="z3998:roman">I</span>.bb. If one is one, all other things are not (<a href="#parmenides-p-1029">159 B</a>⁠–⁠<a href="#parmenides-p-1063">160 B</a>).</p>
+				<p class="hypothesis">
+					<span class="thesis-indent2"><span epub:type="z3998:roman">I</span>.aa. If one has being, all other things are (<a href="#parmenides-p-963">157 B</a>⁠–⁠<a href="#parmenides-p-1029">159 B</a>).</span>
+					<br/>
+					<span class="thesis-indent2"><span epub:type="z3998:roman">I</span>.bb. If one is one, all other things are not (<a href="#parmenides-p-1029">159 B</a>⁠–⁠<a href="#parmenides-p-1063">160 B</a>).</span>
+				</p>
 				<p>The same distinction is then applied to the negative hypothesis:</p>
-				<p class="thesis"><span epub:type="z3998:roman">II</span>.a. If one is not one, it is all things (<a href="#parmenides-p-1063">160 B</a>⁠–⁠<a href="#parmenides-p-1185">163 B</a>).<br/>
-				<span epub:type="z3998:roman">II</span>.b. If one has not being, it is nothing (<a href="#parmenides-p-1185">163 B</a>⁠–⁠<a href="#parmenides-p-1225">164 B</a>).</p>
+				<p class="hypothesis">
+					<span class="thesis-indent2"><span epub:type="z3998:roman">II</span>.a. If one is not one, it is all things (<a href="#parmenides-p-1063">160 B</a>⁠–⁠<a href="#parmenides-p-1185">163 B</a>).</span>
+					<br/>
+					<span class="thesis-indent2"><span epub:type="z3998:roman">II</span>.b. If one has not being, it is nothing (<a href="#parmenides-p-1185">163 B</a>⁠–⁠<a href="#parmenides-p-1225">164 B</a>).</span>
+				</p>
 				<p>Involving two parallel consequences respecting the other or remainder:</p>
-				<p class="thesis"><span epub:type="z3998:roman">II</span>.aa. If one is not one, other things are all (<a href="#parmenides-p-1225">164 B</a>⁠–⁠<a href="#parmenides-p-1275">165 E</a>).<br/>
-				<span><span epub:type="z3998:roman">II</span>.bb. If one has not being, other things are not (<a href="#parmenides-p-1275">165 E</a> to the end).</span></p>
+				<p class="hypothesis">
+					<span class="thesis-indent1"><span epub:type="z3998:roman">II</span>.aa. If one is not one, other things are all (<a href="#parmenides-p-1225">164 B</a>⁠–⁠<a href="#parmenides-p-1275">165 E</a>).</span>
+					<br/>
+					<span class="thesis-indent1"><span epub:type="z3998:roman">II</span>.bb. If one has not being, other things are not (<a href="#parmenides-p-1275">165 E</a> to the end).</span>
+				</p>
 				<hr/>
 				<p>“I cannot refuse,” said Parmenides, “since, as Zeno remarks, we are alone, though I may say with Ibycus, who in his old age fell in love, I, like the old racehorse, tremble at the prospect of the course which I am to run, and which I know so well. But as I must attempt this laborious game, what shall be the subject? Suppose I take my own hypothesis of the one.” “By all means,” said Zeno. “And who will answer me? Shall I propose the youngest? he will be the most likely to say what he thinks, and his answers will give me time to breathe.” “I am the youngest,” said Aristoteles, “and at your service; proceed with your questions.”⁠—The result may be summed up as follows:⁠—</p>
 				<hr/>


### PR DESCRIPTION
Alright, this is my latest attempt on making the hypotheses in Parmenides look correct. (See #35)

It ends up looking like this in my ebook reader:

![parmenides](https://user-images.githubusercontent.com/22407135/173251326-26140b00-6649-4904-8235-e89291f7028d.png)

